### PR TITLE
Feat: timed first epoch release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 settings/settings.json
 .python-version
 auth/settings/auth_settings.json
+logs/

--- a/data_models.py
+++ b/data_models.py
@@ -105,6 +105,7 @@ class SettingsConf(BaseModel):
     validator_epoch_private_key: str
     force_consensus_address: str
     force_consensus_private_key: str
+    epoch_release_start_timestamp: int
 
 
 class Epoch(BaseModel):

--- a/epoch_generator.py
+++ b/epoch_generator.py
@@ -189,6 +189,13 @@ class EpochGenerator:
                 )
                 # there is no point with further retry since this has already been most likely included
                 return
+            else:
+                # re-raise the exception for further retry
+                self._logger.error(
+                    'Unexpected error during epoch release. Submission deets: {}',
+                    submission_info,
+                )
+                raise e
 
         if receipt['status'] != 1:
             self._logger.error(

--- a/epoch_generator.py
+++ b/epoch_generator.py
@@ -192,7 +192,8 @@ class EpochGenerator:
             else:
                 # re-raise the exception for further retry
                 self._logger.error(
-                    'Unexpected error during epoch release. Submission deets: {}',
+                    'Unexpected error during epoch release. Error: {}, Submission deets: {}',
+                    e,
                     submission_info,
                 )
                 raise e

--- a/settings/settings.example.json
+++ b/settings/settings.example.json
@@ -62,5 +62,6 @@
 	"validator_epoch_private_key": "0x000000",
 	"force_consensus_address": "0x000000",
 	"force_consensus_private_key": "0x000000",
-	"ticker_begin_block": 0
+	"ticker_begin_block": 0,
+	"epoch_release_start_timestamp": 0
 }


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #14

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
Epoch generator will wait for X blocks to be mined on startup to satisfy the epoch length before releasing an epoch. 

### New expected behaviour
If given an `epoch_release_start_timestamp` in `settings/settings.json` on initial startup before any epochs have been released on the contract, epoch generator will wait until the given timestamp before releasing the first epoch. If this initial epoch release is successful, it will continue with the main source chain block monitoring loop and release subsequent epochs once the epoch length is satisfied.

### Change logs

#### Added
- `epoch_release_start_timestamp` config in `settings/settings.example.json`


#### Changed
- 'epoch_generator.py` - added a `_wait_and_release_first_epoch` function to handle a timed release of a first epoch when `epoch_release_start_timestamp` is set. The service will function the same as before if no timestamp is set.


## Deployment Instructions
To set a timed release, provide a valid `epoch_release_start_timestamp` in the settings config before starting the service. Invalid timestamps such as those before the current time will cause the service to stop as the timed release can not be completed.
