### PR TITLE
Feat/epoch length one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 settings/settings.json
 .python-version
 auth/settings/auth_settings.json
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pm2 install pm2-logrotate && pm2 set pm2-logrotate:compress true && pm2 set 
 COPY poetry.lock pyproject.toml ./
 
 # Install the Python dependencies
-RUN poetry install --no-dev
+RUN poetry install --no-root
 
 # Copy the rest of the application's files
 COPY . .

--- a/data_models.py
+++ b/data_models.py
@@ -72,6 +72,7 @@ class ChainConfig(BaseModel):
     rpc: RPCConfigBase
     chain_id: int
     epoch: EpochConfig
+    polling_interval: int
 
 
 class AnchorChainConfig(BaseModel):

--- a/epoch_generator.py
+++ b/epoch_generator.py
@@ -162,7 +162,7 @@ class EpochGenerator:
                         # Special handling for epoch height of 1 - use simple polling
                         if settings.chain.epoch.height == 1:
                             polling_interval = getattr(
-                                settings.anchor_chain, 'polling_interval', settings.chain.epoch.block_time // 2,
+                                settings.chain, 'polling_interval', settings.chain.epoch.block_time // 2,
                             )
                             self._logger.debug(
                                 'Current head of source chain estimated at block {} after offsetting | '

--- a/epoch_generator.py
+++ b/epoch_generator.py
@@ -1,32 +1,33 @@
 import asyncio
 import json
+import resource
 import time
 from multiprocessing import Process
 from signal import SIGINT
 from signal import signal
 from signal import SIGQUIT
 from signal import SIGTERM
-from tenacity import retry
-from tenacity import retry_if_exception_type
-from tenacity import stop_after_attempt
-from tenacity import wait_random_exponential
-import resource
 
 import uvloop
 from httpx import AsyncClient
 from httpx import AsyncHTTPTransport
 from httpx import Limits
 from httpx import Timeout
-from web3 import AsyncHTTPProvider, Web3
+from tenacity import retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import wait_random_exponential
+from web3 import AsyncHTTPProvider
 from web3 import AsyncWeb3
+from web3 import Web3
 
 from data_models import GenericTxnIssue
 from exceptions import GenericExitOnSignal
 from helpers.message_models import RPCNodesObject
 from helpers.rpc_helper import ConstructRPC
 from settings.conf import settings
-from utils.helpers import chunks
 from utils.default_logger import logger
+from utils.helpers import chunks
 from utils.notification_utils import send_failure_notifications
 from utils.transaction_utils import write_transaction
 from utils.transaction_utils import write_transaction_with_receipt
@@ -158,19 +159,33 @@ class EpochGenerator:
                 else:
                     end_block_epoch = cur_block - settings.chain.epoch.head_offset
                     if not (end_block_epoch - begin_block_epoch + 1) >= settings.chain.epoch.height:
-                        sleep_factor = settings.chain.epoch.height - \
-                            ((end_block_epoch - begin_block_epoch) + 1)
-                        self._logger.debug(
-                            'Current head of source chain estimated at block {} after offsetting | '
-                            '{} - {} does not satisfy configured epoch length. '
-                            'Sleeping for {} seconds for {} blocks to accumulate....',
-                            end_block_epoch, begin_block_epoch, end_block_epoch,
-                            sleep_factor * settings.chain.epoch.block_time, sleep_factor,
-                        )
-                        await asyncio.sleep(
-                            sleep_factor *
-                            settings.chain.epoch.block_time,
-                        )
+                        # Special handling for epoch height of 1 - use simple polling
+                        if settings.chain.epoch.height == 1:
+                            polling_interval = getattr(
+                                settings.anchor_chain, 'polling_interval', settings.chain.epoch.block_time // 2,
+                            )
+                            self._logger.debug(
+                                'Current head of source chain estimated at block {} after offsetting | '
+                                '{} - {} does not satisfy configured epoch length (height=1). '
+                                'Using simple polling method, sleeping for {} seconds...',
+                                end_block_epoch, begin_block_epoch, end_block_epoch, polling_interval,
+                            )
+                            await asyncio.sleep(polling_interval)
+                        else:
+                            # Original logic for epoch height > 1
+                            sleep_factor = settings.chain.epoch.height - \
+                                ((end_block_epoch - begin_block_epoch) + 1)
+                            self._logger.debug(
+                                'Current head of source chain estimated at block {} after offsetting | '
+                                '{} - {} does not satisfy configured epoch length. '
+                                'Sleeping for {} seconds for {} blocks to accumulate....',
+                                end_block_epoch, begin_block_epoch, end_block_epoch,
+                                sleep_factor * settings.chain.epoch.block_time, sleep_factor,
+                            )
+                            await asyncio.sleep(
+                                sleep_factor *
+                                settings.chain.epoch.block_time,
+                            )
                         continue
                     self._logger.debug(
                         'Chunking blocks between {} - {} with chunk size: {}', begin_block_epoch,
@@ -191,7 +206,9 @@ class EpochGenerator:
                         )
 
                         try:
-                            self._logger.info('Attempting to release epoch {}', epoch_block)
+                            self._logger.info(
+                                'Attempting to release epoch {}', epoch_block,
+                            )
                             if self.release_counter % self._check_receipt_every == 0 or self._force_tx:
                                 self.release_counter += 1
                                 tx_hash, receipt = await write_transaction_with_receipt(
@@ -202,7 +219,9 @@ class EpochGenerator:
                                     'releaseEpoch',
                                     self._nonce,
                                     self.gas if not self._force_tx else self.high_gas,
-                                    Web3.to_checksum_address(settings.data_market_address),
+                                    Web3.to_checksum_address(
+                                        settings.data_market_address,
+                                    ),
                                     epoch_block['begin'],
                                     epoch_block['end'],
                                 )
@@ -246,7 +265,9 @@ class EpochGenerator:
                                     'releaseEpoch',
                                     self._nonce,
                                     self.gas,
-                                    Web3.to_checksum_address(settings.data_market_address),
+                                    Web3.to_checksum_address(
+                                        settings.data_market_address,
+                                    ),
                                     epoch_block['begin'],
                                     epoch_block['end'],
                                 )

--- a/pm2.config.js
+++ b/pm2.config.js
@@ -18,15 +18,6 @@ module.exports = {
       env: {
         NODE_ENV: NODE_ENV,
       }
-    },
-    {
-      name   : "force-consensus",
-      script : `poetry run python -m force_consensus`,
-      max_restarts: MAX_RESTART,
-      min_uptime: MIN_UPTIME,
-      env: {
-        NODE_ENV: NODE_ENV,
-      }
     }
   ]
 }

--- a/settings/settings.example.json
+++ b/settings/settings.example.json
@@ -32,7 +32,8 @@
 			"head_offset": 2,
 			"block_time": 12,
 			"history_length": 1000
-		}
+		},
+		"polling_interval": 2
 	},
 	"anchor_chain": {
 		"rpc": {


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #https://github.com/PowerLoom/epoch-manager/issues/18

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The epoch generation for data markets with an epoch length of 1 currently lags behind due to the polling pattern used for longer epoch lengths.

### New expected behaviour
The epoch generation logic now includes special handling for an epoch height of 1. When `settings.chain.epoch.height` is 1, the system uses a simple polling mechanism with a configurable `polling_interval` (defaults to half the block time) instead of waiting for a larger number of blocks. This allows epochs of height 1 to be processed correctly.

The `force-consensus` process has been removed from the `pm2.config.js` file.

Dependency installation in the Dockerfile now uses `poetry install --no-root` instead of `poetry install --no-dev`.

The `.gitignore` file now includes `logs/`.

### Change logs

#### Added
- Special handling for `epoch.height == 1` in `epoch_generator.py` to use a polling mechanism.
- `polling_interval` field to `ChainConfig` in `data_models.py`.
- `polling_interval` to `settings.example.json`.
- `logs/` to `.gitignore`.

#### Changed
- Modified `Dockerfile` to use `poetry install --no-root` for installing Python dependencies.
- Reordered imports in `epoch_generator.py`.

#### Fixed
- Epoch generation stalling when `epoch.height` is set to 1.

#### Removed
- `force-consensus` process from `pm2.config.js`.

## Deployment Instructions
Ensure the `settings.chain.epoch.height` is configured appropriately. If using an epoch height of 1, you may optionally configure `settings.anchor_chain.polling_interval`.